### PR TITLE
Fix CORE-843: restart nginx master process if killed

### DIFF
--- a/build/go-in-docker.sh
+++ b/build/go-in-docker.sh
@@ -40,7 +40,7 @@ if [ "$missing" = true ];then
   exit 1
 fi
 
-E2E_IMAGE=quay.io/kubernetes-ingress-controller/e2e:v08292018-91eecde
+E2E_IMAGE=quay.io/kubernetes-ingress-controller/e2e:v01262020-44fb2a873
 
 DOCKER_OPTS=${DOCKER_OPTS:-""}
 


### PR DESCRIPTION
* update E2E image used to build the binary
* ensure ngxErrCh channel is initialized, otherwise sends to it will block forever
* when restarting nginx, issue a full sync to synchronize both the nginx.conf file and the the Lua backend state (otherwise all requests will fail with 503)
* also restart nginx process if it was killed with TERM signal (good for testing)

**Testing**:
logged into container, and used ps to get the PID of the nginx master process (child of controller process). In another window, tailed the container's pod. Killed the nginx process with SIGTERM. Observed log entries showing restart of process and full state sync. Ensured HTTP requests to backend services are serviced as expected. Repeated experiment with SIGKILL. Same results.
